### PR TITLE
Fixed typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@ Compete with other participants in weekly project-based assignments.">
 			
 			<div class="timeline-label">
 				<h2><a href="#">Registration Starts:</a> <span>Select the learning path</span></h2>
-				<p>Select from the learning paths we are providing right now, and enroll in the one which suits you the best. All the information the program will be mailed/messaged to the participants.</p>
+				<p>Select from the learning paths we are providing right now, and enroll in the one which suits you the best. All the information about the program will be mailed/messaged to the participants.</p>
 			</div>
 		</div>
 		
@@ -198,7 +198,7 @@ Compete with other participants in weekly project-based assignments.">
 			<div class="timeline-label">
 				<h2>Program officially starts </h2>
 				
-				<p>Access to modules given and resources will be shared each week followed by project assignments/ assessments for 4 weeks, based on which leaderboard will be updated each week.</p>
+				<p>Access to modules will be given and resources will be shared each week followed by project assignments/ assessments for 4 weeks, based on which leaderboard will be updated each week.</p>
 				
 				</div></div>
 		


### PR DESCRIPTION
## Changes
- Fixed typo/grammar error in two lines of the index.html file.

## Additional Required Changes
- The **`Enrol Now`** button on many pages is being redirected to _preregistration.html_ file which has been renamed as _registration.html_, so as a result **404** error is being displayed to all users, that has to be fixed.